### PR TITLE
Fix bug of not handling row_format = 0 (DICT)

### DIFF
--- a/python/pyspark_cassandra/rdd.py
+++ b/python/pyspark_cassandra/rdd.py
@@ -49,8 +49,8 @@ class CassandraRDD(RDD):
 		
 		if not table:
 			raise ValueError("table not set")
-		
-		if not row_format:
+
+		if row_format is None:
 			row_format = RowFormat.ROW
 		elif row_format < 0 or row_format >= len(RowFormat.values):
 			raise ValueError("invalid row_format %s" % row_format)


### PR DESCRIPTION
Casting row_format to bool directly prevents us from handling row_format = 0 which is RowFormat.DICT. This fixes it.