### PR TITLE
Small backwards compatibility issue with python 2.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,7 @@ test-java:
 
 
 
-test-integration: \
-	test-integration-setup \
-	test-integration-matrix \	
-	test-integration-teardown
+test-integration: test-integration-setup test-integration-matrix test-integration-teardown
 
 install-venv:
 	test -d venv || virtualenv venv
@@ -52,11 +49,7 @@ test-integration-setup: start-cassandra
 
 test-integration-teardown: stop-cassandra
 	
-test-integration-matrix:  install-cassandra-driver \
-	test-integration-spark-1.2.1 \
-	test-integration-spark-1.2.2 \
-	test-integration-spark-1.3.0 \
-	test-integration-spark-1.3.1
+test-integration-matrix:  install-cassandra-driver test-integration-spark-1.2.1 test-integration-spark-1.2.2 test-integration-spark-1.3.0 test-integration-spark-1.3.1
 
 test-travis: install-cassandra-driver
 	$(call test-integration-for-version,$$SPARK_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ install-venv:
 	
 install-cassandra-driver: install-venv
 	venv/bin/pip install cassandra-driver
+	venv/bin/pip install unittest2
 	
 install-ccm: install-venv
 	venv/bin/pip install ccm

--- a/Makefile
+++ b/Makefile
@@ -48,21 +48,17 @@ start-cassandra: install-ccm
 stop-cassandra:
 	venv/bin/ccm remove --config-dir=./.ccm
 
-test-integration-setup: \
-	start-cassandra
+test-integration-setup: start-cassandra
 
-test-integration-teardown:
-	stop-cassandra
+test-integration-teardown: stop-cassandra
 	
-test-integration-matrix: \
-	install-cassandra-driver \
+test-integration-matrix:  install-cassandra-driver \
 	test-integration-spark-1.2.1 \
 	test-integration-spark-1.2.2 \
 	test-integration-spark-1.3.0 \
 	test-integration-spark-1.3.1
 
-test-travis: \
-  install-cassandra-driver
+test-travis: install-cassandra-driver
 	$(call test-integration-for-version,$$SPARK_VERSION)
 
 test-integration-spark-1.2.1:
@@ -82,14 +78,14 @@ define test-integration-for-version
 		(pushd lib && curl http://ftp.tudelft.nl/apache/spark/spark-$1/spark-$1-bin-hadoop2.4.tgz | tar xz && popd)
 	
 	cp log4j.properties lib/spark-$1-bin-hadoop2.4/conf/
-
 	source venv/bin/activate ; \
+		export PYTHON_VERSION=`python -V 2>&1| awk '{split($$2,a,".");print a[1] "." a[2]}'`; \
 		lib/spark-$1-bin-hadoop2.4/bin/spark-submit \
 			--master local[*] \
 			--driver-memory 256m \
 			--conf spark.cassandra.connection.host="localhost" \
 			--jars target/pyspark_cassandra-0.1.5.jar \
-			--py-files target/pyspark_cassandra-0.1.5-py2.7.egg \
+			--py-files target/pyspark_cassandra-0.1.5-py$${PYTHON_VERSION}.egg \
 			src/test/python/pyspark_cassandra/it_suite.py
 endef
 

--- a/log4j.properties
+++ b/log4j.properties
@@ -10,4 +10,3 @@ log4j.logger.org.eclipse.jetty=WARN
 log4j.logger.org.eclipse.jetty.util.component.AbstractLifeCycle=ERROR
 log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
 log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO
-

--- a/log4j.properties
+++ b/log4j.properties
@@ -10,3 +10,4 @@ log4j.logger.org.eclipse.jetty=WARN
 log4j.logger.org.eclipse.jetty.util.component.AbstractLifeCycle=ERROR
 log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
 log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO
+

--- a/python/pyspark_cassandra/rdd.py
+++ b/python/pyspark_cassandra/rdd.py
@@ -155,7 +155,7 @@ class SpanningRDD(RDD):
 		def spanning_iterator(partition):
 			def key_by(columns):
 				for row in partition:
-					k = Row(lambda c: [ row.__getattr__(c) for c in columns])
+					k = Row(**dict((c, row.__getattr__(c)) for c in columns))	
 					for c in columns:
 						del row[c]
 					

--- a/python/pyspark_cassandra/rdd.py
+++ b/python/pyspark_cassandra/rdd.py
@@ -155,7 +155,7 @@ class SpanningRDD(RDD):
 		def spanning_iterator(partition):
 			def key_by(columns):
 				for row in partition:
-					k = Row(**{c: row.__getattr__(c) for c in columns})
+					k = Row(lambda c: [ row.__getattr__(c) for c in columns])
 					for c in columns:
 						del row[c]
 					

--- a/python/pyspark_cassandra/types.py
+++ b/python/pyspark_cassandra/types.py
@@ -33,7 +33,7 @@ def _create_udt(fields, values):
 	return _create_struct(UDT, fields, values)
 
 def _create_struct(cls, fields, values):
-	d = [lambda k: v for k, v in zip(fields, values)]
+	d = dict((k, v) for k, v in zip(fields, values))
 	return cls(**d)
 
 
@@ -85,7 +85,7 @@ class Struct(tuple):
 		return self.__class__(**d)
 
 	def __sub__(self, other):
-		d = lambda k: [ v for k, v in self.__FIELDS__.items() if k in other ]
+		d = dict( (v,v) for k, v in self.__FIELDS__.items() if k in other )
 		return self.__class__(**d)
 
 	
@@ -167,7 +167,7 @@ def _create_spanning_dataframe(cnames, ctypes, cvalues):
 	# otherwise use lists	
 	global np
 	convert = _to_nparrays if np else _to_list
-	arrays =  lambda n :[ convert(t, v) for n, t, v in zip(cnames, ctypes, cvalues) ]
+	arrays =  dict((n, convert(t, v)) for n, t, v in zip(cnames, ctypes, cvalues) )
 	
 	# if pandas is available, provide the arrays / lists as DataFrame
 	# otherwise use pyspark_cassandra.Row

--- a/python/pyspark_cassandra/types.py
+++ b/python/pyspark_cassandra/types.py
@@ -33,7 +33,7 @@ def _create_udt(fields, values):
 	return _create_struct(UDT, fields, values)
 
 def _create_struct(cls, fields, values):
-	d = {k: v for k, v in zip(fields, values)}
+	d = [lambda k: v for k, v in zip(fields, values)]
 	return cls(**d)
 
 
@@ -85,7 +85,7 @@ class Struct(tuple):
 		return self.__class__(**d)
 
 	def __sub__(self, other):
-		d = { k:v for k, v in self.__FIELDS__.items() if k in other }
+		d = lambda k: [ v for k, v in self.__FIELDS__.items() if k in other ]
 		return self.__class__(**d)
 
 	
@@ -167,7 +167,7 @@ def _create_spanning_dataframe(cnames, ctypes, cvalues):
 	# otherwise use lists	
 	global np
 	convert = _to_nparrays if np else _to_list
-	arrays = { n : convert(t, v) for n, t, v in zip(cnames, ctypes, cvalues) }
+	arrays =  lambda n :[ convert(t, v) for n, t, v in zip(cnames, ctypes, cvalues) ]
 	
 	# if pandas is available, provide the arrays / lists as DataFrame
 	# otherwise use pyspark_cassandra.Row

--- a/src/test/python/pyspark_cassandra/it_suite.py
+++ b/src/test/python/pyspark_cassandra/it_suite.py
@@ -34,8 +34,8 @@ class CassandraTestCase(unittest.TestCase):
     def tearDownClass(cls):
 	if sys.version_info >= (2, 7):
 	        super(CassandraTestCase, cls).setUpClass()
-        	cls.session.shutdown()
-        	cls.sc.stop()
+        	CassandraTestCase.session.shutdown()
+        	CassandraTestCase.sc.stop()
 
   
 
@@ -53,7 +53,7 @@ class SimpleTypesTest(CassandraTestCase):
     @classmethod
     def setUpClass(cls):
         super(SimpleTypesTest, cls).setUpClass()
-        cls.session.execute('''
+        CassandraTestCase.session.execute('''
             CREATE TABLE IF NOT EXISTS simple_types (
                 key text primary key, %s
             )
@@ -61,7 +61,7 @@ class SimpleTypesTest(CassandraTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.session.execute('DROP TABLE simple_types')
+        CassandraTestCase.session.execute('DROP TABLE simple_types')
         super(SimpleTypesTest, cls).tearDownClass()
 
     def setUp(self):
@@ -153,7 +153,7 @@ class CollectionTypesTest(CassandraTestCase):
     @classmethod
     def setUpClass(cls):
         super(CollectionTypesTest, cls).setUpClass()
-        cls.session.execute('''
+        CassandraTestCase.session.execute('''
             CREATE TABLE IF NOT EXISTS %s (
                 key text primary key, %s
             )

--- a/src/test/python/pyspark_cassandra/it_suite.py
+++ b/src/test/python/pyspark_cassandra/it_suite.py
@@ -53,7 +53,7 @@ class SimpleTypesTest(CassandraTestCase):
     @classmethod
     def setUpClass(cls):
         super(SimpleTypesTest, cls).setUpClass()
-       	cls.session.execute('''
+        cls.session.execute('''
             CREATE TABLE IF NOT EXISTS simple_types (
                 key text primary key, %s
             )
@@ -62,7 +62,7 @@ class SimpleTypesTest(CassandraTestCase):
     @classmethod
     def tearDownClass(cls):
         cls.session.execute('DROP TABLE simple_types')
-# 	super(SimpleTypesTest, cls).tearDownClass()
+        super(SimpleTypesTest, cls).tearDownClass()
 
     def setUp(self):
         super(SimpleTypesTest, self).setUp()


### PR DESCRIPTION
Getting an invalid syntax on Centos 6.6 on Python 2.6.6
Python 2.6.6 (r266:84292, Jan 22 2014, 09:42:36) 
[GCC 4.4.7 20120313 (Red Hat 4.4.7-4)] on linux2

```
/opt/spark/spark-1.3.1-bin-hadoop2.6/bin/spark-submit --py-files /opt/spark/pyspark-cassandra/target/pyspark_cassandra-0.1.5-py2.6.egg --jars /opt/spark/pyspark-cassandra/target/pyspark_cassandra-0.1.5.jar --driver-class-path /opt/spark/pyspark-cassandra/target/pyspark_cassandra-0.1.5.jar ./cassandra-streaming-test.py
[...]
File "/root/alex/./cassandra-streaming-test.py", line 4, in <module>
    import pyspark_cassandra
  File "build/bdist.linux-x86_64/egg/pyspark_cassandra/__init__.py", line 23, in <module>
  File "build/bdist.linux-x86_64/egg/pyspark_cassandra/context.py", line 16, in <module>
  File "/opt/spark/pyspark-cassandra/target/pyspark_cassandra-0.1.5-py2.6.egg/pyspark_cassandra/rdd.py", line 158
    k = Row(**{c: row.__getattr__(c) for c in columns})
                                       ^
SyntaxError: invalid syntax
```

Mind you I'm not a python expert by any measure.
