### PR TITLE
Fields order maintained when pickling UDT

### DIFF
--- a/src/main/java/pyspark_cassandra/types/UDTValuePickler.java
+++ b/src/main/java/pyspark_cassandra/types/UDTValuePickler.java
@@ -33,7 +33,9 @@ public class UDTValuePickler extends StructPickler {
 
 	@Override
 	public Collection<String> getFieldNames(Object o) {
-		return ((UDTValue) o).getType().getFieldNames();
+		//The returned generic Collection does not guarantee order and it would sometimes turn into 
+		//a python set -- we need the fieldnames to be sorted for pickling!
+		return new ArrayList(((UDTValue) o).getType().getFieldNames());
 	}
 
 	@Override


### PR DESCRIPTION
Fixes the problem reported on #41 with unordered field names. 

http://docs.datastax.com/en/drivers/java/2.1/com/datastax/driver/core/UserType.html#getFieldNames%28%29