### PR TITLE
Update spark-cassandra-connector to 1.4.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL = /bin/bash
-VERSION = $(shell grep ^version build.sbt | sed 's/version := //g' | sed 's/"//g')
+VERSION = $(shell grep ^version build.sbt | sed 's/^version := //g' | sed 's/"//g')
 
 .PHONY: clean clean-pyc clean-dist dist test-travis
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL = /bin/bash
-VERSION = $(shell grep version build.sbt | sed 's/version := //g' | sed 's/"//g')
+VERSION = $(shell grep ^version build.sbt | sed 's/version := //g' | sed 's/"//g')
 
 .PHONY: clean clean-pyc clean-dist dist test-travis
 

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ credentials += Credentials(Path.userHome / ".ivy2" / ".sbtcredentials")
 licenses += "Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0") 
 
 libraryDependencies ++= Seq(
-	"com.datastax.spark" %% "spark-cassandra-connector-java" % "1.4.0"
+	"com.datastax.spark" %% "spark-cassandra-connector-java" % "1.4.1"
 )
 
 spName := "TargetHolding/pyspark-cassandra"
@@ -25,5 +25,12 @@ javacOptions ++= Seq("-source", "1.7", "-target", "1.7")
 assemblyOption in assembly := (assemblyOption in assembly).value.copy(
 	includeScala = false
 )
+
+assemblyMergeStrategy in assembly := {
+	case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.last
+	case x =>
+		val oldStrategy = (assemblyMergeStrategy in assembly).value
+		oldStrategy(x)
+}
 
 EclipseKeys.withSource := true


### PR DESCRIPTION
Hi,

In spark-cassandra-connector 1.4.0 there is a bug which stops us from serializing cassandra dataframes to parquet files when cassandra table contains DateTime columns:

```python
reader.load(keyspace="ks", table="table").write.save("table.parquet")
```

results in:

```
java.lang.ClassCastException: java.util.Date cannot be cast to java.sql.Timestamp
	at org.apache.spark.sql.parquet.RowWriteSupport.writePrimitive(ParquetTableSupport.scala:207)
	at org.apache.spark.sql.parquet.RowWriteSupport.writeValue(ParquetTableSupport.scala:192)
	at org.apache.spark.sql.parquet.RowWriteSupport$$anonfun$writeMap$2.apply(ParquetTableSupport.scala:288)
	at org.apache.spark.sql.parquet.RowWriteSupport$$anonfun$writeMap$2.apply(ParquetTableSupport.scala:281)
	at scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:772)
	at scala.collection.immutable.HashMap$HashMap1.foreach(HashMap.scala:224)
	at scala.collection.immutable.HashMap$HashTrieMap.foreach(HashMap.scala:403)
	at scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:771)
	at org.apache.spark.sql.parquet.RowWriteSupport.writeMap(ParquetTableSupport.scala:281)
	at org.apache.spark.sql.parquet.RowWriteSupport.writeValue(ParquetTableSupport.scala:186)
	at org.apache.spark.sql.parquet.RowWriteSupport.write(ParquetTableSupport.scala:171)
	at org.apache.spark.sql.parquet.RowWriteSupport.write(ParquetTableSupport.scala:134)
	at parquet.hadoop.InternalParquetRecordWriter.write(InternalParquetRecordWriter.java:120)
	at parquet.hadoop.ParquetRecordWriter.write(ParquetRecordWriter.java:81)
	at parquet.hadoop.ParquetRecordWriter.write(ParquetRecordWriter.java:37)
	at org.apache.spark.sql.parquet.ParquetOutputWriter.write(newParquet.scala:86)
	at org.apache.spark.sql.sources.InsertIntoHadoopFsRelation.org$apache$spark$sql$sources$InsertIntoHadoopFsRelation$$writeRows$1(commands.scala:183)
	at org.apache.spark.sql.sources.InsertIntoHadoopFsRelation$$anonfun$insert$1.apply(commands.scala:160)
	at org.apache.spark.sql.sources.InsertIntoHadoopFsRelation$$anonfun$insert$1.apply(commands.scala:160)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:63)
	at org.apache.spark.scheduler.Task.run(Task.scala:70)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:213)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)
```

This bug has been fixed in https://datastax-oss.atlassian.net/browse/SPARKC-254 and patched in 1.4.1 so I thought that would be nice to bring it to pyspark-cassandra. I tested it with our code and everything seems to work ok. Also I had to override merge strategy for netty packages because they generated version conflicts during sbt assembly (datastax developers also had to address it with https://github.com/datastax/spark-cassandra-connector/blob/v1.4.1/project/Settings.scala#L238)