### PR TITLE
Indicate where to find the new maintained repository location for Spark 2.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 PySpark Cassandra
 =================
 
-PySpark Cassandra is no longer maintained. Development effort has moved away from Spark to pure Python environment.
+**This PySpark Cassandra repository is no longer maintained. Please check this repository for Spark 2.0+ support: https://github.com/anguenot/pyspark-cassandra**
 
 ---
 


### PR DESCRIPTION
2 versions have already been published supporting Spark 2.0+ and latest `spark-cassandra-connector`: https://spark-packages.org/package/anguenot/pyspark-cassandra

Note, this fork repository (`ilanddev/pyspark-cassandra`) is only aimed at submitting that one PR for this  doc update since the `anguenot/pyspark-cassandra` fork has been disconnected so that I could publish to spark-packages.org.

Let me know if you have questions. 

Thanks. 

   J.